### PR TITLE
Fix akka-wamp documentation over HTTPS

### DIFF
--- a/projects/akka-wamp/index.html
+++ b/projects/akka-wamp/index.html
@@ -8,7 +8,7 @@
   <title>akka-wamp-0.3.0</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 


### PR DESCRIPTION
When using HTTPS Everywhere, the blocked HTTP URL gave the appearance that no documentation existed.
